### PR TITLE
Add WebSocket subscriptions and REST endpoint support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -13,7 +13,9 @@
     "@std/assert": "jsr:@std/assert@1",
     "@std/cli": "jsr:@std/cli@^1.0.6",
     "@std/testing": "jsr:@std/testing@^1.0.3",
+    "graphql": "npm:graphql@^16.9.0",
     "graphql-scalars": "npm:graphql-scalars@^1.23.0",
+    "graphql-ws": "npm:graphql-ws@^5.16.0",
     "graphql-yoga": "npm:graphql-yoga@^5.7.0"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,5 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
     "jsr:@joyautomation/coral@^0.0.10": "0.0.10",
     "jsr:@joyautomation/dark-matter@^0.0.13": "0.0.13",
@@ -16,7 +16,9 @@
     "jsr:@std/testing@^1.0.3": "1.0.3",
     "npm:@pothos/core@^4.2.0": "4.2.0_graphql@16.9.0",
     "npm:graphql-scalars@^1.23.0": "1.23.0_graphql@16.9.0",
-    "npm:graphql-yoga@^5.7.0": "5.7.0_graphql@16.9.0"
+    "npm:graphql-ws@^5.16.0": "5.16.2_graphql@16.12.0",
+    "npm:graphql-yoga@^5.7.0": "5.7.0_graphql@16.9.0",
+    "npm:graphql@^16.9.0": "16.12.0"
   },
   "jsr": {
     "@joyautomation/coral@0.0.10": {
@@ -93,7 +95,7 @@
         "@graphql-tools/utils",
         "@graphql-typed-document-node/core",
         "@repeaterjs/repeater",
-        "graphql",
+        "graphql@16.9.0",
         "tslib",
         "value-or-promise"
       ]
@@ -102,7 +104,7 @@
       "integrity": "sha512-lbTrIuXIbUSmSumHkPRY1QX0Z8JEtmRhnIrkH7vkfeEmf0kNn/nCWvJwqokm5U7L+a+DA1wlRM4slIlbfXjJBA==",
       "dependencies": [
         "@graphql-tools/utils",
-        "graphql",
+        "graphql@16.9.0",
         "tslib"
       ]
     },
@@ -111,7 +113,7 @@
       "dependencies": [
         "@graphql-tools/merge",
         "@graphql-tools/utils",
-        "graphql",
+        "graphql@16.9.0",
         "tslib",
         "value-or-promise"
       ]
@@ -122,14 +124,14 @@
         "@graphql-typed-document-node/core",
         "cross-inspect",
         "dset",
-        "graphql",
+        "graphql@16.9.0",
         "tslib"
       ]
     },
     "@graphql-typed-document-node/core@3.2.0_graphql@16.9.0": {
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "dependencies": [
-        "graphql"
+        "graphql@16.9.0"
       ]
     },
     "@graphql-yoga/logger@2.0.0": {
@@ -160,7 +162,7 @@
     "@pothos/core@4.2.0_graphql@16.9.0": {
       "integrity": "sha512-dEoQCaA/pCPg3MhjGCwBF1QRbtOPysXm4nivQQsq6OrOvC7pU+KJNVdBSwpi1ZtTLtd4wg+PCC8Js9GrCyh9sw==",
       "dependencies": [
-        "graphql"
+        "graphql@16.9.0"
       ]
     },
     "@repeaterjs/repeater@3.0.6": {
@@ -222,8 +224,14 @@
     "graphql-scalars@1.23.0_graphql@16.9.0": {
       "integrity": "sha512-YTRNcwitkn8CqYcleKOx9IvedA8JIERn8BRq21nlKgOr4NEcTaWEG0sT+H92eF3ALTFbPgsqfft4cw+MGgv0Gg==",
       "dependencies": [
-        "graphql",
+        "graphql@16.9.0",
         "tslib"
+      ]
+    },
+    "graphql-ws@5.16.2_graphql@16.12.0": {
+      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
+      "dependencies": [
+        "graphql@16.12.0"
       ]
     },
     "graphql-yoga@5.7.0_graphql@16.9.0": {
@@ -238,10 +246,13 @@
         "@whatwg-node/fetch",
         "@whatwg-node/server",
         "dset",
-        "graphql",
+        "graphql@16.9.0",
         "lru-cache",
         "tslib"
       ]
+    },
+    "graphql@16.12.0": {
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="
     },
     "graphql@16.9.0": {
       "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw=="
@@ -271,7 +282,9 @@
       "jsr:@std/testing@^1.0.3",
       "npm:@pothos/core@^4.2.0",
       "npm:graphql-scalars@^1.23.0",
-      "npm:graphql-yoga@^5.7.0"
+      "npm:graphql-ws@^5.16.0",
+      "npm:graphql-yoga@^5.7.0",
+      "npm:graphql@^16.9.0"
     ]
   }
 }

--- a/server.ts
+++ b/server.ts
@@ -1,9 +1,20 @@
 import { createYoga } from "graphql-yoga";
+import {
+  makeHandler,
+  GRAPHQL_TRANSPORT_WS_PROTOCOL,
+} from "graphql-ws/lib/use/deno";
 import { validateHost, validatePort } from "./validation.ts";
 import type { Args } from "@std/cli";
 import { setLogLevel, type Log } from "@joyautomation/coral";
 import { getBuilder } from "./graphql.ts";
 import { initContextCache } from "@pothos/core";
+
+// Type definition for REST endpoints
+export type RestEndpoint = {
+  path: string;
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS';
+  handler: (request: Request) => Response | Promise<Response>;
+};
 
 /**
  * Logger interface used by the server
@@ -30,7 +41,8 @@ export function createRunServer<Context extends object>(
   ) =>
     | ReturnType<typeof getBuilder<Context>>
     | Promise<ReturnType<typeof getBuilder<Context>>>,
-  beforeServe?: (args: Args) => void | Promise<void>
+  beforeServe?: (args: Args) => void | Promise<void>,
+  restEndpoints?: RestEndpoint[]
 ): (
   name: string,
   info: string,
@@ -76,6 +88,21 @@ export function createRunServer<Context extends object>(
         };
       },
     });
+
+    // Create WebSocket handler for graphql-ws subscriptions
+    // Schema type assertion needed: graphql-yoga and graphql-ws resolve
+    // different graphql package versions with incompatible private fields,
+    // but the runtime types are structurally identical.
+    const wsHandler = subscriptions
+      ? makeHandler({
+          schema: schema as Parameters<typeof makeHandler>[0]["schema"],
+          context: () => ({
+            ...initContextCache(),
+            ...context,
+          }),
+        })
+      : null;
+
     if (beforeServe) {
       await beforeServe(args);
     }
@@ -97,7 +124,47 @@ export function createRunServer<Context extends object>(
           log.info(`${name} graphQL api is running on ${hostname}:${port}`);
         },
       },
-      yoga.fetch
+      async (request: Request, connInfo: Deno.ServeHandlerInfo) => {
+        // Handle WebSocket upgrades for graphql-ws subscriptions
+        if (
+          wsHandler &&
+          request.headers.get("upgrade")?.toLowerCase() === "websocket"
+        ) {
+          const { socket, response } = Deno.upgradeWebSocket(request, {
+            protocol: GRAPHQL_TRANSPORT_WS_PROTOCOL,
+            idleTimeout: 12_000,
+          });
+          wsHandler(socket);
+          return response;
+        }
+
+        // Handle REST endpoints if provided
+        if (restEndpoints && restEndpoints.length > 0) {
+          const url = new URL(request.url);
+          const path = url.pathname;
+          const method = request.method;
+
+          // Find matching REST endpoint
+          const endpoint = restEndpoints.find(
+            (e) => e.path === path && e.method === method
+          );
+
+          if (endpoint) {
+            try {
+              return await endpoint.handler(request);
+            } catch (error) {
+              log.error(`Error in REST endpoint ${method} ${path}:`, error);
+              return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' }
+              });
+            }
+          }
+        }
+
+        // Default to GraphQL handler (HTTP queries/mutations + SSE subscriptions)
+        return yoga.fetch(request, connInfo);
+      }
     );
   };
 }


### PR DESCRIPTION
## Summary
- Add `graphql-ws` WebSocket subscription support using the official Deno adapter (`makeHandler` + `GRAPHQL_TRANSPORT_WS_PROTOCOL`)
- WebSocket upgrades are handled before REST and GraphQL-yoga routes when `subscriptions` is enabled
- Add optional `restEndpoints` parameter to `createRunServer` for custom HTTP route handlers

## Test plan
- [ ] Verify `deno check` passes
- [ ] Test WebSocket subscriptions connect with `graphql-transport-ws` protocol
- [ ] Verify SSE subscriptions still work via graphql-yoga
- [ ] Verify REST endpoints route correctly when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)